### PR TITLE
Add type: DATETIME to search query to prevent elastic errors

### DIFF
--- a/includes/js/wp-proud-search.js
+++ b/includes/js/wp-proud-search.js
@@ -45,7 +45,7 @@ var decodeEntities = (function () {
       // analytics for search page
       if (searchPage) {
         $body.once('proud-search-ga', function () {
-          if (ga === undefined) {
+          if (typeof ga === 'undefined') {
             return;
           }
           // Send page view

--- a/wp-proud-search.php
+++ b/wp-proud-search.php
@@ -377,6 +377,7 @@ class ProudSearch extends \ProudPlugin {
 					),
 					array(
 						'key' => '_event_start_local',
+						'type' => 'DATETIME',
 						'compare' => '>=',
 						'value' => date('Y-m-d H:i:s'),
 					),


### PR DESCRIPTION
Without type: DATETIME in the WP_Query `meta_query`, elastic was interpreting this comparison as a double:
<img width="736" alt="Screenshot 2024-01-18 at 11 06 17 PM" src="https://github.com/proudcity/wp-proud-search/assets/1634686/4ac1c8cc-f673-4d04-be64-51f92f86c2c0">

After addition:
<img width="801" alt="Screenshot 2024-01-18 at 11 06 45 PM" src="https://github.com/proudcity/wp-proud-search/assets/1634686/067aaa5a-61ae-4ef4-a79b-3c8808b2a4db">
